### PR TITLE
Use API gateway for orders

### DIFF
--- a/frontend/src/pages/orders/OrderSummary.tsx
+++ b/frontend/src/pages/orders/OrderSummary.tsx
@@ -1,11 +1,29 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { useOrders } from '../../hooks/useOrders';
+import { useOrders, type Order } from '../../hooks/useOrders';
+import useApi from '../../hooks/useApi';
 
 const OrderSummary: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const { getOrderById } = useOrders();
-  const order = getOrderById(Number(id));
+  const api = useApi();
+  const [order, setOrder] = useState<Order | undefined>();
+  const [paid, setPaid] = useState(false);
+
+  useEffect(() => {
+    const load = async () => {
+      if (!id) return;
+      const fetched = await getOrderById(Number(id));
+      setOrder(fetched);
+      try {
+        const payment = await api.get<{ status: string }>(`/api/payments/${id}`);
+        setPaid(payment?.status === 'completed' || payment?.status === 'paid');
+      } catch (err) {
+        console.error('Failed to load payment', err);
+      }
+    };
+    load();
+  }, [id, getOrderById, api]);
 
   if (!order) {
     return <div className="p-4">Order not found.</div>;
@@ -27,7 +45,7 @@ const OrderSummary: React.FC = () => {
         </ul>
         <div className="font-bold mt-2">Total: KES {order.total}</div>
       </div>
-      {!order.paid && (
+      {!paid && (
         <Link
           to={`/orders/${order.id}/pay`}
           className="inline-block bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"
@@ -35,7 +53,7 @@ const OrderSummary: React.FC = () => {
           Proceed to Payment
         </Link>
       )}
-      {order.paid && (
+      {paid && (
         <span className="text-green-600 font-bold">Payment Received</span>
       )}
       <Link to="/orders/history" className="block text-blue-600 mt-4">

--- a/frontend/src/pages/orders/PayOrder.tsx
+++ b/frontend/src/pages/orders/PayOrder.tsx
@@ -1,19 +1,38 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useOrders } from '../../hooks/useOrders';
+import { useOrders, type Order } from '../../hooks/useOrders';
+import useApi from '../../hooks/useApi';
 
 const PayOrder: React.FC = () => {
   const { id } = useParams<{ id: string }>();
   const { getOrderById, payOrder } = useOrders();
-  const order = getOrderById(Number(id));
+  const api = useApi();
+  const [order, setOrder] = useState<Order | undefined>();
+  const [paid, setPaid] = useState(false);
   const navigate = useNavigate();
+
+  useEffect(() => {
+    const load = async () => {
+      if (!id) return;
+      const fetched = await getOrderById(Number(id));
+      setOrder(fetched);
+      try {
+        const payment = await api.get<{ status: string }>(`/api/payments/${id}`);
+        setPaid(payment?.status === 'completed' || payment?.status === 'paid');
+      } catch (err) {
+        console.error('Failed to fetch payment', err);
+      }
+    };
+    load();
+  }, [id, getOrderById, api]);
 
   if (!order) {
     return <div className="p-4">Order not found.</div>;
   }
 
-  const handlePay = () => {
-    payOrder(order.id);
+  const handlePay = async () => {
+    await payOrder(order.id, order.total);
+    setPaid(true);
     navigate(`/orders/${order.id}/summary`);
   };
 
@@ -22,7 +41,7 @@ const PayOrder: React.FC = () => {
       <h1 className="text-2xl font-bold">Pay for Order #{order.id}</h1>
       <div className="bg-white p-4 rounded shadow">
         <div className="font-bold mb-2">Total: KES {order.total}</div>
-        {order.paid ? (
+        {paid ? (
           <span className="text-green-600 font-bold">Already Paid</span>
         ) : (
           <button

--- a/frontend/src/pages/orders/PlaceOrder.tsx
+++ b/frontend/src/pages/orders/PlaceOrder.tsx
@@ -8,7 +8,7 @@ const PlaceOrder: React.FC = () => {
   const { placeOrder } = useOrders();
   const navigate = useNavigate();
 
-  const handlePlaceOrder = () => {
+  const handlePlaceOrder = async () => {
     if (cart.length === 0) return;
     const items: OrderItem[] = cart.map((c) => ({
       id: c.id,
@@ -16,7 +16,7 @@ const PlaceOrder: React.FC = () => {
       price: c.price,
       quantity: 1,
     }));
-    const order = placeOrder(items);
+    const order = await placeOrder(items);
     clearCart();
     navigate(`/orders/${order.id}/summary`);
   };


### PR DESCRIPTION
## Summary
- refactor orders hook to call API instead of local storage
- fetch orders and payments from backend in summary and pay pages
- make placing an order async

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684c032ee6f883258ac9f7a44b41e51d