### PR TITLE
Integrate payment client into Orders service

### DIFF
--- a/apps/orders/src/orders.module.ts
+++ b/apps/orders/src/orders.module.ts
@@ -18,6 +18,17 @@ import { PrismaService } from './prisma.service';
           },
         },
       },
+      {
+        name: 'PAYMENT_SERVICE',
+        transport: Transport.RMQ,
+        options: {
+          urls: ['amqp://localhost:5672'],
+          queue: 'payment_queue',
+          queueOptions: {
+            durable: false,
+          },
+        },
+      },
     ]),
   ],
   controllers: [OrdersController],

--- a/apps/orders/src/orders.service.ts
+++ b/apps/orders/src/orders.service.ts
@@ -7,12 +7,15 @@ export class OrdersService {
   constructor(
     private prisma: PrismaService,
     @Inject('MENU_SERVICE') private readonly kitchenClient: ClientProxy,
+    @Inject('PAYMENT_SERVICE') private readonly paymentClient: ClientProxy,
   ) {}
 
   async createOrder(data: any) {
     const order = await this.prisma.order.create({ data });
     // Notify kitchen service about the new order
     this.kitchenClient.emit({ cmd: 'order_created' }, order);
+    // Trigger billing process for the order
+    this.paymentClient.emit({ cmd: 'initiate_billing' }, order);
     return order;
   }
 


### PR DESCRIPTION
## Summary
- register `PAYMENT_SERVICE` in `OrdersModule`
- inject payment client in `OrdersService`
- emit `initiate_billing` event when an order is created

## Testing
- `npm test` *(fails: Your test suite must contain at least one test)*

------
https://chatgpt.com/codex/tasks/task_e_684c0320a7a88325ba6631cdd2078c83