### PR TITLE
Add ORDERS service integration for payments

### DIFF
--- a/apps/payments/src/payments.module.ts
+++ b/apps/payments/src/payments.module.ts
@@ -1,10 +1,25 @@
 import { Module } from '@nestjs/common';
+import { ClientsModule, Transport } from '@nestjs/microservices';
 import { PaymentsController } from './payments.controller';
 import { PaymentsService } from './payments.service';
 import { PrismaService } from './prisma.service';
 
 @Module({
-  imports: [],
+  imports: [
+    ClientsModule.register([
+      {
+        name: 'ORDERS_SERVICE',
+        transport: Transport.RMQ,
+        options: {
+          urls: ['amqp://localhost:5672'],
+          queue: 'orders_queue',
+          queueOptions: {
+            durable: false,
+          },
+        },
+      },
+    ]),
+  ],
   controllers: [PaymentsController],
   providers: [PaymentsService, PrismaService],
 })


### PR DESCRIPTION
## Summary
- register ORDERS_SERVICE client in payments module
- emit `payment_confirmed` event after payment creation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c0325e91883258418a34a9a5fe60f