### PR TITLE
Add shared order status enum

### DIFF
--- a/apps/menu/prisma/schema.prisma
+++ b/apps/menu/prisma/schema.prisma
@@ -14,11 +14,18 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum OrderStatus {
+  Queued
+  InProgress
+  Ready
+  Completed
+}
+
 model KitchenOrder {
   id         String   @id @default(auto()) @map("_id") @db.ObjectId
   orderId    Int
   item       String
-  status     String   @default("queued") // 'queued' | 'preparing' | 'ready'
+  status     OrderStatus @default(Queued)
   receivedAt DateTime @default(now())
   preparedAt DateTime?
 

--- a/apps/menu/src/menu.controller.ts
+++ b/apps/menu/src/menu.controller.ts
@@ -1,6 +1,7 @@
 import { Controller } from '@nestjs/common';
 import { EventPattern, MessagePattern } from '@nestjs/microservices';
 import { KitchenService } from './menu.service';
+import { OrderStatus } from '../../libs/common/order-status.enum';
 
 @Controller()
 export class KitchenController {
@@ -14,13 +15,13 @@ export class KitchenController {
   @MessagePattern({ cmd: 'start_preparing' })
   startPreparing(data: { orderId: number }) {
     console.log(`Starting preparation for order #${data.orderId}`);
-    return this.kitchenService.updateStatus(data.orderId, 'preparing');
+    return this.kitchenService.updateStatus(data.orderId, OrderStatus.InProgress);
   }
 
   @MessagePattern({ cmd: 'mark_ready' })
   markReady(data: { orderId: number }) {
     console.log(`Marking order #${data.orderId} as ready`);
-    return this.kitchenService.updateStatus(data.orderId, 'ready');
+    return this.kitchenService.updateStatus(data.orderId, OrderStatus.Ready);
   }
 
   @MessagePattern({ cmd: 'update_menu_item' })

--- a/apps/menu/src/menu.service.ts
+++ b/apps/menu/src/menu.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from './prisma.service';
+import { OrderStatus } from '../../libs/common/order-status.enum';
 
 @Injectable()
 export class KitchenService {
@@ -21,15 +22,18 @@ export class KitchenService {
       data: {
         orderId: order.orderId,
         item: order.item,
-        status: 'queued',
+        status: OrderStatus.Queued,
       },
     });
   }
 
-  async updateStatus(orderId: number, status: 'preparing' | 'ready') {
+  async updateStatus(orderId: number, status: OrderStatus) {
     return this.prisma.kitchenOrder.updateMany({
       where: { orderId },
-      data: { status, preparedAt: status === 'ready' ? new Date() : undefined },
+      data: {
+        status,
+        preparedAt: status === OrderStatus.Ready ? new Date() : undefined,
+      },
     });
   }
 
@@ -37,7 +41,7 @@ export class KitchenService {
     return this.prisma.kitchenOrder.findMany();
   }
 
-  async findByStatus(status: string) {
+  async findByStatus(status: OrderStatus) {
     return this.prisma.kitchenOrder.findMany({ where: { status } });
   }
 

--- a/apps/orders/prisma/schema.prisma
+++ b/apps/orders/prisma/schema.prisma
@@ -16,11 +16,18 @@ datasource db {
   schemas  = ["payments", "orders"]
 }
 
+enum OrderStatus {
+  Queued
+  InProgress
+  Ready
+  Completed
+}
+
 model Order {
   id            Int      @id @default(autoincrement())
   customerId    Int      @map("customer_id")
   item          String
-  status        String
+  status        OrderStatus @default(Queued)
   totalAmount   Float    @map("total_amount")
   paymentMethod String   @map("payment_method")
   createdAt     DateTime @default(now()) @map("created_at")

--- a/apps/orders/src/orders.service.ts
+++ b/apps/orders/src/orders.service.ts
@@ -1,6 +1,7 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { PrismaService } from './prisma.service';
 import { ClientProxy } from '@nestjs/microservices';
+import { OrderStatus } from '../../libs/common/order-status.enum';
 
 @Injectable()
 export class OrdersService {
@@ -36,7 +37,7 @@ export class OrdersService {
     return this.prisma.order.findMany({ where: { customerId } });
   }
 
-  findByStatus(status: string) {
+  findByStatus(status: OrderStatus) {
     return this.prisma.order.findMany({ where: { status } });
   }
 

--- a/apps/payments/prisma/schema.prisma
+++ b/apps/payments/prisma/schema.prisma
@@ -14,12 +14,19 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+enum OrderStatus {
+  Queued
+  InProgress
+  Ready
+  Completed
+}
+
 model Payment {
   id            Int       @id @default(autoincrement())
   orderId       Int
   amount        Float
   method        String
-  status        String    @default("pending")
+  status        OrderStatus @default(Queued)
   transactionId String?
   createdAt     DateTime  @default(now())
   updatedAt     DateTime  @updatedAt

--- a/apps/payments/src/payments.service.ts
+++ b/apps/payments/src/payments.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from './prisma.service';
+import { OrderStatus } from '../../libs/common/order-status.enum';
 
 @Injectable()
 export class PaymentsService {
@@ -9,8 +10,14 @@ export class PaymentsService {
     amount: number;
     method: string;
     transactionId?: string;
+    status?: OrderStatus;
   }) {
-    return this.prisma.payment.create({ data });
+    return this.prisma.payment.create({
+      data: {
+        ...data,
+        status: data.status ?? OrderStatus.Queued,
+      },
+    });
   }
 
   async getPayment(orderId: number) {

--- a/libs/common/order-status.enum.ts
+++ b/libs/common/order-status.enum.ts
@@ -1,0 +1,6 @@
+export enum OrderStatus {
+  Queued = 'Queued',
+  InProgress = 'InProgress',
+  Ready = 'Ready',
+  Completed = 'Completed',
+}


### PR DESCRIPTION
## Summary
- add `OrderStatus` enum under `libs/common`
- use `OrderStatus` in Prisma schemas across `orders`, `menu`, and `payments`
- update service logic to reference shared enum

## Testing
- `npm test` *(fails: Your test suite must contain at least one test)*

------
https://chatgpt.com/codex/tasks/task_e_684c032a65e88325a23681f3e2547f95